### PR TITLE
req-reply, attempt 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# improv logs
+global.log
+

--- a/arduino/send_trigger_serial/send_trigger_serial.ino
+++ b/arduino/send_trigger_serial/send_trigger_serial.ino
@@ -1,0 +1,15 @@
+int trigger_pin = 38;
+
+void setup() {
+  // put your setup code here, to run once:
+  Serial.begin(9600);
+  pinMode(trigger_pin, INPUT);
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+  //delayMicroseconds(1);
+  int trigger_state = digitalRead(trigger_pin);
+  Serial.print(trigger_state);
+  Serial.print("\n");
+}

--- a/matlab/SerenityClient.m
+++ b/matlab/SerenityClient.m
@@ -129,6 +129,8 @@ classdef SerenityClient < handle
             tic;
             % wait for server to acknowledge
             while true
+                obj.socket.setReqRelaxed(1);
+                obj.socket.setReqCorrelate(0);
                 reply = obj.socket.recv(obj.ZMQ_NOBLOCK);
                 if toc > 30
                     error("Timeout exceeded for confirming acquisition end")

--- a/matlab/SerenityClient.m
+++ b/matlab/SerenityClient.m
@@ -45,6 +45,8 @@ classdef SerenityClient < handle
             import org.zeromq.*;
 
             obj.ZMQ_NOBLOCK = ZMQ.NOBLOCK;
+            
+            obj.address = address;
 
             % connect to server, client is in PUSH configuration
             obj.context = ZContext();
@@ -55,12 +57,17 @@ classdef SerenityClient < handle
 
             obj.acq_ready = false;
             obj.uid = "";
-
-            disp("Successfully connected!")
-            obj.address = address;
-
+            
             obj.parent_buffer_path = parent_buffer_path;
             obj.current_buffer_path = "";
+            
+            disp("Successfully connected!")
+        end
+
+        function reset(obj)
+            obj.socket.setLinger(0);
+            obj.socket.close()
+            obj.socket.connect(obj.address);
         end
 
         function prep_acq(obj, metadata)
@@ -146,6 +153,7 @@ classdef SerenityClient < handle
                 obj.acq_ready = false;
                 obj.uid = "";
                 obj.acq_metadata = "";
+                break
             end
         end
 

--- a/matlab/SerenityClient.m
+++ b/matlab/SerenityClient.m
@@ -22,10 +22,10 @@ classdef SerenityClient < handle
         socket
         acq_metadata
         acq_ready
-        ZMsg
+        uid
         parent_buffer_path
         current_buffer_path
-        bg_pool
+        ZMQ_NOBLOCK
     end
 
     properties(SetAccess=protected, GetAccess=public)
@@ -44,16 +44,18 @@ classdef SerenityClient < handle
             % import zeromq
             import org.zeromq.*;
 
+            obj.ZMQ_NOBLOCK = ZMQ.NOBLOCK;
+
             % connect to server, client is in PUSH configuration
             obj.context = ZContext();
-            obj.socket = obj.context.createSocket(SocketType.PUSH);
+            obj.socket = obj.context.createSocket(SocketType.REQ);
             obj.socket.connect(address);
-            obj.acq_ready = false;
 
-            obj.ZMsg = ZMsg;
+            obj.acq_ready = false;
+            obj.uid = "";
+
             disp("Successfully connected!")
             obj.address = address;
-            disp(obj.address)
 
             obj.parent_buffer_path = parent_buffer_path;
             obj.current_buffer_path = "";
@@ -61,82 +63,83 @@ classdef SerenityClient < handle
 
         function prep_acq(obj, metadata)
             % prepare acquisition
-            obj.socket.send("acquisition-prep-incoming");
+            % get acq metadata
             acq_meta = jsonencode(metadata);
+
+            % send to serenity server
             obj.socket.send(acq_meta);
-            obj.socket.send("acquisition-prep-sent");
-            % TODO: Would be nice to receive validation response from server
-            obj.acq_ready = true;
-            disp("Acquisition data sent, check if received on server")
-            obj.acq_metadata = metadata;
-            obj.current_buffer_path = fullfile(obj.parent_buffer_path, "test");
-            mkdir(obj.current_buffer_path)
-        end
+            tic;
+            % wait for server to acknowledge
+            while true
+                reply = obj.socket.recv(obj.ZMQ_NOBLOCK);
+                if toc > 10
+                    error("Timeout exceeded for confirming acquisition start")
+                end
+                % reply not yet received, try again
+                if isempty(reply)
+                    % wait for 0.5s
+                    pause(0.5)
+                    continue
+                end
+                % get string representation from bytes
+                response = convertCharsToStrings(native2unicode(reply));
+                % if there was a failure
+                if startsWith(response, "Failed")
+                    error(response)
+                else
+                    % uuid of this acquisition
+                    obj.uid = response;
+                    % ready for acquisition
+                    obj.acq_ready = true;
+                    % acq metadata
+                    obj.acq_metadata = metadata;
+                    % make path for frame buffer
+                    obj.current_buffer_path = fullfile(obj.parent_buffer_path, obj.uid);
+                    mkdir(obj.current_buffer_path)
 
-        function send_frame(obj, src)
-            % sends frame to zmq socket
-            % src: scanimage hSI object
-
-%             if obj.acq_ready ~= true
-%                 ex = MException("Acquisition is not preped. Call pre_acq() first.");
-%                 throw(ex)
-%             end
-            % get data from scanimage
-            last_stripe = src.hSI.hDisplay.stripeDataBuffer{src.hSI.hDisplay.stripeDataBufferPointer};
-
-            msg = obj.ZMsg();
-            % frame index
-            msg.add(getByteStreamFromArray(uint32(last_stripe.frameNumberAcq)));
-            % trial index
-            msg.add(getByteStreamFromArray(uint32(0)));
-            % trigger state
-            msg.add(getByteStreamFromArray(uint32(0)));
-            % timestamp
-            msg.add(getByteStreamFromArray(single(last_stripe.frameTimestamp)));
-
-            % frame data
-            for channel_ix = 1:length(last_stripe.roiData{1}.channels)
-                msg.add(getByteStreamFromArray(last_stripe.roiData{1}.imageData{channel_ix}{1}(:)));
+                    disp("Acquisition prepped successfully with uid:")
+                    disp(obj.uid)
+                    break
+                end
             end
-
-            % send
-            msg.send(obj.socket);
         end
         
         function new_frame_ready(obj, src)
             last_stripe = src.hSI.hDisplay.stripeDataBuffer{src.hSI.hDisplay.stripeDataBufferPointer};
-            parfeval(backgroundPool, @obj.write_buffer, 0, last_stripe)
+            %parfeval(obj.pool, @write_buffer, 0, obj.current_buffer_path, last_stripe);
+            write_buffer(obj.current_buffer_path, last_stripe)
         end
 
-        function write_buffer(obj, last_stripe)
-            % write frame to buffer on disk
-            % frame index
-            frame_index = getByteStreamFromArray(uint32(last_stripe.frameNumberAcq));
-            
-            fname = strcat(num2str(last_stripe.frameNumberAcq), ".bin");
-            fid = fopen(fullfile(obj.current_buffer_path, fname), "w");
-
-            fwrite(fid, frame_index)
-
-            % trial index
-            fwrite(fid, getByteStreamFromArray(uint32(0)));
-            % trigger state
-            fwrite(fid, getByteStreamFromArray(uint32(0)));
-            % timestamp
-            fwrite(fid, getByteStreamFromArray(single(last_stripe.frameTimestamp)));
-
-            % frame data
-            for channel_ix = 1:length(last_stripe.roiData{1}.channels)
-                fwrite(fid, getByteStreamFromArray(last_stripe.roiData{1}.imageData{channel_ix}{1}(:)));
-            end
-
-            fclose(fid);
-        end
-
-        function end_acq(obj)
+        function end_acq(obj, src)
             obj.acq_ready = false;
-            obj.socket.send("acquisition-end")
-            disp("Acquisition ended")
+            obj.uid = "";
+
+            last_stripe = src.hSI.hDisplay.stripeDataBuffer{src.hSI.hDisplay.stripeDataBufferPointer};
+            frame_index = getByteStreamFromArray(uint32(last_stripe.frameNumberAcq));
+
+            % get index of last frame
+            obj.socket.send(frame_index)
+
+            % wait for serenity server to end acq
+            tic;
+            % wait for server to acknowledge
+            while true
+                reply = obj.socket.recv(obj.ZMQ_NOBLOCK);
+                if toc > 30
+                    error("Timeout exceeded for confirming acquisition end")
+                    break
+                end
+                if isempty(reply)
+                    pause(0.5)
+                    continue
+                end
+                response = convertCharsToStrings(native2unicode(reply));
+                disp(response)
+                % reset
+                obj.acq_ready = false;
+                obj.uid = "";
+                obj.acq_metadata = "";
+            end
         end
 
         function speed_test(obj, src, n_frames)

--- a/matlab/SerenityClient.m
+++ b/matlab/SerenityClient.m
@@ -49,6 +49,8 @@ classdef SerenityClient < handle
             % connect to server, client is in PUSH configuration
             obj.context = ZContext();
             obj.socket = obj.context.createSocket(SocketType.REQ);
+            obj.socket.setReqRelaxed(1);
+            obj.socket.setReqCorrelate(0);
             obj.socket.connect(address);
 
             obj.acq_ready = false;
@@ -117,7 +119,10 @@ classdef SerenityClient < handle
             last_stripe = src.hSI.hDisplay.stripeDataBuffer{src.hSI.hDisplay.stripeDataBufferPointer};
             frame_index = getByteStreamFromArray(uint32(last_stripe.frameNumberAcq));
 
-            % get index of last frame
+            % send index of last frame
+            obj.socket.setReqRelaxed(1);
+            obj.socket.setReqCorrelate(0);
+
             obj.socket.send(frame_index)
 
             % wait for serenity server to end acq

--- a/matlab/end_acq.m
+++ b/matlab/end_acq.m
@@ -1,0 +1,7 @@
+function end_acq(src, evt, vargin)
+    persistent local_sc;
+    if isempty(local_sc)
+        local_sc = evalin("base", "sc");
+    end
+    local_sc.end_acq(src);
+end

--- a/matlab/frame_sender.m
+++ b/matlab/frame_sender.m
@@ -1,0 +1,9 @@
+function frame_sender(src, evt, vargin)
+    % wrapper function since scanimage only takes 
+    % function name strings and not actual objects
+    persistent local_sc;
+    if isempty(local_sc)
+        local_sc = evalin("base", "sc");
+    end
+    local_sc.new_frame_ready(src);
+end

--- a/matlab/make_acq_metadata_green_red.m
+++ b/matlab/make_acq_metadata_green_red.m
@@ -6,22 +6,22 @@ acq_meta = get_automated_acq_meta(hSI);
 
 %%
 % *BOLD TEXT* 
-acq_meta.database = "/data/kushal/layer1-db/batch.parquet";
+acq_meta.database = "/data/kushal/layer1-db/batch.h5";
 acq_meta.animal_id = "mouse_1";
 
 % set green channel data
 acq_meta.channels{1}.index = 0;
-acq_meta.channels{1}.name = "axons";
+acq_meta.channels{1}.name = "va-axons";
 acq_meta.channels{1}.indicator = "gcamp8f";
 acq_meta.channels{1}.color = "green";
-acq_meta.channels{1}.genotype = "necab-gcamp8f";
+acq_meta.channels{1}.genotype = "necab-gcamp8f+aav-syn-flex-gcamp8f";
 
 % set red channel data
 acq_meta.channels{2}.index = 1; 
-acq_meta.channels{2}.name = "l1-interneurons";
+acq_meta.channels{2}.name = "pyr-dendrites";
 acq_meta.channels{2}.indicator = "rcamp";
 acq_meta.channels{2}.color = "red";
-acq_meta.channels{2}.genotype = "";
+acq_meta.channels{2}.genotype = "retro-aav-sl1-cag-rcamp1b";
 
 % this sub session
 acq_meta.sub_session = 0;

--- a/matlab/make_acq_metadata_green_red.m
+++ b/matlab/make_acq_metadata_green_red.m
@@ -3,7 +3,10 @@ acq_meta = get_automated_acq_meta(hSI);
 
 % Set these manually per-acquisition
 % set acquisition data
-acq_meta.database = "/data/kushal/layer1-mesmerize";
+
+%%
+% *BOLD TEXT* 
+acq_meta.database = "/data/kushal/layer1-db/batch.parquet";
 acq_meta.animal_id = "mouse_1";
 
 % set green channel data

--- a/matlab/make_acq_metadata_green_red.m
+++ b/matlab/make_acq_metadata_green_red.m
@@ -23,5 +23,13 @@ acq_meta.channels{2}.indicator = "rcamp";
 acq_meta.channels{2}.color = "red";
 acq_meta.channels{2}.genotype = "";
 
+% this sub session
+acq_meta.sub_session = 0;
+
 % optional comments
 acq_meta.comments = "";
+
+
+clear frame_sender
+sc = SerenityClient("tcp://127.0.0.1:9005", "C:/Users/scanimage/serenity_buffer");
+sc.prep_acq(acq_meta)

--- a/matlab/make_acq_metadata_green_red.m
+++ b/matlab/make_acq_metadata_green_red.m
@@ -31,5 +31,7 @@ acq_meta.comments = "";
 
 
 clear frame_sender
+clear write_buffer
 sc = SerenityClient("tcp://127.0.0.1:9005", "C:/Users/scanimage/serenity_buffer");
 sc.prep_acq(acq_meta)
+hSI.startGrab()

--- a/matlab/metadata/get_scanimage_metadata.m
+++ b/matlab/metadata/get_scanimage_metadata.m
@@ -23,7 +23,8 @@ function meta = get_scanimage_metadata(hsi)
         "hShutters",
         "hDisplay",
         "hUserFunctions",
-        "hScan2D"
+        "hScan2D",
+        "hStackManager"  % this contains info such as how many frames the user has set to capture
     };
 
     % each meta data field
@@ -51,6 +52,10 @@ function meta = get_scanimage_metadata(hsi)
     % remove some non-serializable objects
     meta.hBeams = rmfield(meta.hBeams, "pzFunction ");
     meta.hBeams = rmfield(meta.hBeams, "hBeams");
+
+    % remove last frame data since this is not necessary
+    meta.hDisplay = rmfield(meta.hDisplay, "lastFrame");
+    meta.hDisplay = rmfield(meta.hDisplay, "lastAveragedFrame");
     
     % remove shutter data for now 
     % contains lots of non-serializable hardware objcs

--- a/matlab/open_arduino.m
+++ b/matlab/open_arduino.m
@@ -1,0 +1,5 @@
+ard_device = serial("COM5");
+ard_device.InputBufferSize = 6;
+ard_device.ReadAsyncMode = "manual";
+ard_device.Terminator = "LF";
+fopen(ard_device);

--- a/matlab/serenity_frame_sender.m
+++ b/matlab/serenity_frame_sender.m
@@ -1,7 +1,0 @@
-function serenity_frame_sender(src, evt, vargin)
-    % wrapper function since scanimage only takes 
-    % function name strings and not actual objects
-    persistent local_sc;
-    local_sc = evalin("base", "sc");
-    local_sc.send_frame(src);
-end

--- a/matlab/write_buffer.m
+++ b/matlab/write_buffer.m
@@ -1,17 +1,23 @@
 function write_buffer(buffer_path, last_stripe)
+    persistent ard
+    if isempty(ard)
+        ard = evalin("base", "ard_device");
+    end
+
     % write frame to buffer on disk
     % frame index
-    frame_index = getByteStreamFromArray(uint32(last_stripe.frameNumberAcq));
+    ix = last_stripe.frameNumberAcq;
     
-    fname = strcat(num2str(last_stripe.frameNumberAcq), ".bin");
+    fname = strcat(num2str(ix), ".bin");
     fid = fopen(fullfile(buffer_path, fname), "w");
-
-    fwrite(fid, frame_index);
+    
+    % write frame index
+    fwrite(fid, getByteStreamFromArray(uint32(ix)));
 
     % trial index
     fwrite(fid, getByteStreamFromArray(uint32(0)));
     % trigger state
-    fwrite(fid, getByteStreamFromArray(uint32(0)));
+    fwrite(fid, getByteStreamFromArray(uint32(fread(ard))));
     % timestamp
     fwrite(fid, getByteStreamFromArray(single(last_stripe.frameTimestamp)));
 

--- a/matlab/write_buffer.m
+++ b/matlab/write_buffer.m
@@ -1,0 +1,24 @@
+function write_buffer(buffer_path, last_stripe)
+    % write frame to buffer on disk
+    % frame index
+    frame_index = getByteStreamFromArray(uint32(last_stripe.frameNumberAcq));
+    
+    fname = strcat(num2str(last_stripe.frameNumberAcq), ".bin");
+    fid = fopen(fullfile(buffer_path, fname), "w");
+
+    fwrite(fid, frame_index);
+
+    % trial index
+    fwrite(fid, getByteStreamFromArray(uint32(0)));
+    % trigger state
+    fwrite(fid, getByteStreamFromArray(uint32(0)));
+    % timestamp
+    fwrite(fid, getByteStreamFromArray(single(last_stripe.frameTimestamp)));
+
+    % frame data
+    for channel_ix = 1:length(last_stripe.roiData{1}.channels)
+        fwrite(fid, getByteStreamFromArray(last_stripe.roiData{1}.imageData{channel_ix}{1}(:)));
+    end
+
+    fclose(fid);
+end

--- a/matlab/write_buffer.m
+++ b/matlab/write_buffer.m
@@ -3,13 +3,16 @@ function write_buffer(buffer_path, last_stripe)
     if isempty(ard)
         ard = evalin("base", "ard_device");
     end
+    persistent trigger_val
+    if isempty(trigger_val)
+        trigger_val = 0;
+    end
 
     % write frame to buffer on disk
     % frame index
     ix = last_stripe.frameNumberAcq;
     
-    fname = strcat(num2str(ix), ".bin");
-    fid = fopen(fullfile(buffer_path, fname), "w");
+    fid = fopen(fullfile(buffer_path, strcat(num2str(ix), ".bin")), "w");
     
     % write frame index
     fwrite(fid, getByteStreamFromArray(uint32(ix)));
@@ -17,7 +20,19 @@ function write_buffer(buffer_path, last_stripe)
     % trial index
     fwrite(fid, getByteStreamFromArray(uint32(0)));
     % trigger state
-    fwrite(fid, getByteStreamFromArray(uint32(fread(ard))));
+    state = fgetl(ard);  % as a string
+
+    % in case empty character array because matlab is weird
+    if isempty(state)
+        % just use previous state
+        state = trigger_val;
+    end
+    
+    % use last character of in case it's like '00' because matlab is weird
+    % in reading serial
+    trigger_val = state;
+    fwrite(fid, getByteStreamFromArray(uint32(str2double(state(end)))));
+    %fwrite(fid, getByteStreamFromArray(uint32(0)));
     % timestamp
     fwrite(fid, getByteStreamFromArray(single(last_stripe.frameTimestamp)));
 
@@ -26,5 +41,9 @@ function write_buffer(buffer_path, last_stripe)
         fwrite(fid, getByteStreamFromArray(last_stripe.roiData{1}.imageData{channel_ix}{1}(:)));
     end
 
+    fclose(fid);
+
+    % signal that frame buffer is ready to be read
+    fid = fopen(fullfile(buffer_path, strcat(num2str(ix), ".done")), "w");
     fclose(fid);
 end

--- a/serenity/__init__.py
+++ b/serenity/__init__.py
@@ -1,0 +1,1 @@
+from . import actors

--- a/serenity/__init__.py
+++ b/serenity/__init__.py
@@ -1,3 +1,11 @@
+from warnings import warn
+
+
 from . import actors
-from .mesmerize_utils import load_batch, create_batch
-from .extensions import AcquisitionSeriesExtensions, AcquisitionDataFrameExtensions
+from . import io
+
+try:
+    from .mesmerize_utils import load_batch, create_batch
+    from .extensions import AcquisitionSeriesExtensions, AcquisitionDataFrameExtensions
+except:
+    warn("mesmerize not found, this is fine if you just need to run SerenityServer")

--- a/serenity/__init__.py
+++ b/serenity/__init__.py
@@ -1,1 +1,3 @@
 from . import actors
+from .mesmerize_utils import load_batch, create_batch
+from .extensions import AcquisitionSeriesExtensions, AcquisitionDataFrameExtensions

--- a/serenity/actors/datamanager.py
+++ b/serenity/actors/datamanager.py
@@ -64,6 +64,9 @@ class ScanImageReceiver(Actor):
         else:
             return b
 
+    def _reply_frame_received(self, index: int):
+        pass
+
     def runStep(self):
         """
         Receives data from zmq socket, puts it in the queue.
@@ -74,10 +77,12 @@ class ScanImageReceiver(Actor):
 
         # TODO: make sure we don't have a memory leak here
         b = self._receive_bytes()
-        frame = TwoPhotonFrame.from_zmq_multipart(b, self.acquisition_metadata)
 
         if b is None:
             return
+
+        frame = TwoPhotonFrame.from_zmq_multipart(b, self.acquisition_metadata)
+        self._reply_frame_received(frame.index)
 
         self.q_out.put(frame.to_bytes())
 

--- a/serenity/actors/datamanager.py
+++ b/serenity/actors/datamanager.py
@@ -107,6 +107,10 @@ class ScanImageReceiver(Actor):
         if b is None:
             return
 
+        if b == b"end-acq":
+            self.socket.send(b"acquisition ended")
+            return
+
         # we expect that this is json encoded acq metadata
         if not self.acq_ready:
             try:

--- a/serenity/actors/datamanager.py
+++ b/serenity/actors/datamanager.py
@@ -2,7 +2,11 @@ from typing import *
 from queue import Empty
 import logging
 from collections import deque
-from uuid import uuid4
+from pathlib import Path
+import traceback
+
+import pandas as pd
+from mesmerize_core import load_batch
 
 import numpy as np
 import tifffile
@@ -11,6 +15,7 @@ import zmq
 from improv.actor import Actor
 
 from serenity.io import AcquisitionMetadata, TwoPhotonFrame
+from serenity.extensions import AcquisitionDataFrameExtensions, AcquisitionSeriesExtensions
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -52,6 +57,7 @@ class ScanImageReceiver(Actor):
 
         # received frame indices
         self.received_indices: List[int] = list()
+        self.last_frame_index: int = -1
 
         # increment trial_index whenever we get a [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
         # this is the rising edge of the trigger
@@ -103,17 +109,23 @@ class ScanImageReceiver(Actor):
 
         # we expect that this is json encoded acq metadata
         if not self.acq_ready:
-            uid = uuid4()
-            self.acq_meta = AcquisitionMetadata.from_json(b, uid)
+            try:
+                self.acq_meta = AcquisitionMetadata.from_jsons(b, generate_uuid=True)
 
-            # reply to socket
-            self.socket.send_string(str(uid))
+                # reply to socket
+                # just send the first uid if using two channels, doesn't matter for matlab
+                uids = self.acq_meta.uuids
 
-            self.current_uid = uid
-            self.acq_ready = True
-            # self downstream
-            self.q_out.put(self.acq_meta.to_json())
-            return
+                self.acq_ready = True
+                # self downstream
+                self.q_out.put(self.acq_meta.to_json())
+            except Exception as e:
+                self.socket.send_string(f"Failure in starting acquisition\n{e}\n{traceback.format_exc()}")
+            else:
+                self.socket.send_string("_".join(uids))
+                logger.info(f"********** UUID in receiver ********\n{self.acq_meta.uuids}")
+            finally:
+                return
 
         # else, this is a frame, parse and send
         try:
@@ -121,10 +133,10 @@ class ScanImageReceiver(Actor):
         except Exception as e:
             # bad frame, request new one
             self.socket.send("bad frame".encode("utf-8"))
-            logger.error(f"Bad frame after index: {self.current_trial_index}")
+            logger.error(f"Bad frame after index: {self.last_frame_index}")
             return
         else:
-            # goo frame, reply frame index
+            # good frame, reply frame index
             self._reply_frame_received(frame.index)
 
         # this is a new frame
@@ -138,6 +150,7 @@ class ScanImageReceiver(Actor):
             # MUST be numpy array, else to_bytes doesn't work!
             frame.trial_index = np.array([self.current_trial_index], dtype=np.uint32)
             self.q_out.put(frame.to_bytes())
+            self.last_frame_index = frame.index
         # in case a frame was received but the reply wasn't received on the other end
         else:
             # send reply again
@@ -164,14 +177,18 @@ class MesmerizeWriter(Actor):
         # super(MesmerizeWriter, self).__init__(*args, name="MesmerizeWriter", **kwargs)
         super().__init__(*args, **kwargs)
 
+        # mesmerize batch dir for this acquisition
         self.acq_meta: AcquisitionMetadata = None
         self.writers: List[tifffile.TiffWriter] = None
-        self.acquisition_nframes: int = None
+        self.movie_paths: List[Path] = None
+        self.header_paths: List[Path] = None
+
+        self.dataframe: pd.DataFrame = None
 
     def setup(self):
         logger.info("Mesmerize Writer ready")
 
-    def _get_frame(self) -> bytes | None:
+    def _get_bytes(self) -> bytes | None:
         """
         Gets frame from ScanImageReceiver
         """
@@ -189,9 +206,10 @@ class MesmerizeWriter(Actor):
         """
         Reset the state of this actor to get ready for next acquisition
         """
-        self.acq_meta = None
-        self.writers = None
-        self.acquisition_nframes = None
+        self.acq_meta: AcquisitionMetadata = None
+        self.writers: List[tifffile.TiffWriter] = None
+        self.movie_paths: List[Path] = None
+        self.header_paths: List[Path] = None
 
     def stop(self):
         for w in self.writers:
@@ -199,35 +217,40 @@ class MesmerizeWriter(Actor):
 
         return 0
 
+    def _setup_new_acq(self, bytes_acq_meta):
+        self.acq_meta = AcquisitionMetadata.from_jsons(bytes_acq_meta)
+
+        logger.info(f"********** UUID in mesmerize writer ********\n{self.acq_meta.uuids}")
+
+        # load mesmerize dataframe
+        self.dataframe = load_batch(self.acq_meta.database, file_format="parquet")
+
+        self.movie_paths, self.header_paths = self.dataframe.acq.add_item(acq_meta=self.acq_meta)
+
+        self.writers = list()
+        for i in range(len(self.acq_meta.channels)):
+            self.writers.append(tifffile.TiffWriter(self.movie_paths[i], bigtiff=True))
+
     def runStep(self):
         """
         Writes data to a mesmerize database
         """
-        frame = self._get_frame()
+        b = self._get_bytes()
 
-        if frame is None:
+        if b is None:
             return
 
         # TODO: write header data to disk as well
         # set acq metadata
         if self.acq_meta is None:
-            self.acq_meta = AcquisitionMetadata.from_json(frame)
-            self.acq_meta.to_disk(f"/data/kushal/improv-testing/{self.acq_meta.uid}.json")
-
-            # make file to store frame headers
-            self.acq_meta.create_header_file(f"/data/kushal/improv-testing/{self.acq_meta.uid}.header")
-
-            self.writers = list()
-            for channel in self.acq_meta.channels:
-                color = channel.color
-                self.writers.append(tifffile.TiffWriter(f"/data/kushal/improv-testing/{color}.tiff", bigtiff=True))
+            self._setup_new_acq(b)
 
             return
 
-        frame = TwoPhotonFrame.from_bytes(frame, self.acq_meta)
+        frame = TwoPhotonFrame.from_bytes(b, self.acq_meta)
 
-        for writer, channel_data in zip(self.writers, frame.channels):
+        for i, (writer, channel_data) in enumerate(zip(self.writers, frame.channels)):
             writer.write(channel_data)
 
-        # append header of current frame to header file
-        frame.append_header_file(f"/data/kushal/improv-testing/{self.acq_meta.uid}.header")
+            # append header of current frame to header file
+            frame.append_header_file(self.header_paths[i], channel=i)

--- a/serenity/actors/datamanager.py
+++ b/serenity/actors/datamanager.py
@@ -137,7 +137,8 @@ class ScanImageReceiver(Actor):
         except Exception as e:
             # bad frame, request new one
             self.socket.send("bad frame".encode("utf-8"))
-            logger.error(f"Bad frame after index: {self.last_frame_index}")
+            logger.error(f"Bad frame after index: {self.last_frame_index}\n")
+            logger.error(traceback.format_exc())
             return
         else:
             # good frame, reply frame index

--- a/serenity/extensions/__init__.py
+++ b/serenity/extensions/__init__.py
@@ -1,0 +1,1 @@
+from .data import AcquisitionDataFrameExtensions, AcquisitionSeriesExtensions

--- a/serenity/extensions/data.py
+++ b/serenity/extensions/data.py
@@ -20,6 +20,13 @@ class AcquisitionSeriesExtensions:
     def __init__(self, series: pd.Series):
         self._series = series
 
+    def get_item_dir(self) -> Path:
+        return self._series.paths.get_batch_path().parent.joinpath(self.uuid)
+
+    @property
+    def uuid(self) -> str:
+        return self._series["uuid"]
+
     # TODO: make mesmerize cache decorator more easily accessible so I can use it here
     def get_meta(self) -> AcquisitionMetadata:
         """
@@ -31,13 +38,11 @@ class AcquisitionSeriesExtensions:
             acquisition metadata object
         """
         # "batch_path/uuid/uuid.json"
-        u = self._series["uuid"]
-        path = self._series.paths.get_batch_path().joinpath(u, f"{u}.json")
+        path = self.get_item_dir().joinpath(f"{self.uuid}.json")
         return AcquisitionMetadata.from_json(path)
 
     def get_header(self) -> Dict[str, np.ndarray]:
-        u = self._series["uuid"]
-        path = self._series.paths.get_batch_path().joinpath(u, f"{u}.header")
+        path = self.get_item_dir().joinpath(f"{self.uuid}.header")
 
         with h5py.File(path, "r") as f:
             header = dict.fromkeys(f.keys())

--- a/serenity/extensions/data.py
+++ b/serenity/extensions/data.py
@@ -1,0 +1,128 @@
+from typing import *
+from pathlib import Path
+import logging
+
+import numpy as np
+import pandas as pd
+import h5py
+import tifffile
+
+from mesmerize_core.batch_utils import PathsDataFrameExtension, PathsSeriesExtension
+
+from ..io import AcquisitionMetadata, TwoPhotonFrame
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+@pd.api.extensions.register_series_accessor("acq")
+class AcquisitionSeriesExtensions:
+    def __init__(self, series: pd.Series):
+        self._series = series
+
+    # TODO: make mesmerize cache decorator more easily accessible so I can use it here
+    def get_meta(self) -> AcquisitionMetadata:
+        """
+        Get the acquisition metadata
+
+        Returns
+        -------
+        AcquisitionMetadata
+            acquisition metadata object
+        """
+        # "batch_path/uuid/uuid.json"
+        u = self._series["uuid"]
+        path = self._series.paths.get_batch_path().joinpath(u, f"{u}.json")
+        return AcquisitionMetadata.from_json(path)
+
+    def get_header(self) -> Dict[str, np.ndarray]:
+        u = self._series["uuid"]
+        path = self._series.paths.get_batch_path().joinpath(u, f"{u}.header")
+
+        with h5py.File(path, "r") as f:
+            header = dict.fromkeys(f.keys())
+            for k in header.keys():
+                # should be fine to just return the entire array for each header element
+                # even if there are 10 header elements and 100,000 frames that is only
+                # 100,000 * 10 * 4 bytes = 4 megabytes
+                header[k] = f[k][()]
+
+        return header
+
+
+@pd.api.extensions.register_dataframe_accessor("acq")
+class AcquisitionDataFrameExtensions:
+    def __init__(self, dataframe: pd.DataFrame):
+        self._dataframe = dataframe
+
+    def add_item(self, acq_meta: AcquisitionMetadata) -> Tuple[List[Path], List[Path]]:
+        """
+        Add an item to start acquisition
+
+        Parameters
+        ----------
+        acq_meta: AcquisitionMetadata
+
+        Returns
+        -------
+        Tuple[List[Path], List[Path]]
+            ([input_movie_paths], [header_paths])
+        """
+        batch_dir: Path = self._dataframe.paths.get_batch_path().parent
+
+        # input movie paths are returned, order corresponds to channel order
+        input_movie_paths = list()
+        # also returns paths to headers so they can be appended
+        header_paths = list()
+
+        logger.info(f"********** UUID in add_item ********\n{acq_meta.uuids}")
+
+        for i in range(len(acq_meta.channels)):
+            channel = acq_meta.channels[i]
+            uid = acq_meta.uuids[i]
+
+            # make dir for this item only
+            item_path = batch_dir.joinpath(uid)
+            item_path.mkdir()
+
+            # full path to input movie
+            input_movie_path = item_path.joinpath("raw.tiff")
+            input_movie_paths.append(input_movie_path)
+            # path relative to batch_dir
+            relative_input_movie_path = self._dataframe.paths.split(input_movie_path)[1]
+
+            s = pd.Series(
+                {
+                    "uuid": uid,
+                    "input_movie_path": str(relative_input_movie_path),
+                    "algo": "onacid",
+                    "animal_id": acq_meta.animal_id,
+                    "framerate": acq_meta.framerate,
+                    "date": acq_meta.date,
+                    "comments": acq_meta.comments,
+                    "channel_index": channel.index,
+                    "channel_name": channel.name,
+                    "channel_colors": channel.color,
+                    "channel_genotype": channel.genotype,
+                    "channel_indicator": channel.indicator,
+                }
+            )
+
+            logger.info(uid)
+            logger.info(str(s))
+
+            # write metadata to disk
+            acq_meta.to_disk(item_path.joinpath(f"{uid}.json"))
+
+            # create header file that is ready to go
+            header_path = item_path.joinpath(f"{uid}.header")
+            acq_meta.create_header_file(header_path, channel=i)
+            header_paths.append(header_path)
+
+            # Add the Series to the DataFrame
+            self._dataframe.loc[self._dataframe.index.size] = s
+
+            # Save DataFrame to disk
+            self._dataframe.to_parquet(self._dataframe.paths.get_batch_path())
+
+        return input_movie_paths, header_paths

--- a/serenity/extensions/data.py
+++ b/serenity/extensions/data.py
@@ -96,18 +96,23 @@ class AcquisitionDataFrameExtensions:
             # path relative to batch_dir
             relative_input_movie_path = self._dataframe.paths.split(input_movie_path)[1]
 
+            item_name = f"{acq_meta.animal_id}_{acq_meta.date}"
+
             s = pd.Series(
                 {
                     "uuid": uid,
+                    "item_name": item_name,
                     "input_movie_path": str(relative_input_movie_path),
                     "algo": "onacid",
+                    "params": {"main": None},  # parquet doesn't support empty dicts
                     "animal_id": acq_meta.animal_id,
                     "framerate": acq_meta.framerate,
                     "date": acq_meta.date,
+                    "sub_session": acq_meta.sub_session,
                     "comments": acq_meta.comments,
                     "channel_index": channel.index,
                     "channel_name": channel.name,
-                    "channel_colors": channel.color,
+                    "channel_color": channel.color,
                     "channel_genotype": channel.genotype,
                     "channel_indicator": channel.indicator,
                 }
@@ -128,6 +133,7 @@ class AcquisitionDataFrameExtensions:
             self._dataframe.loc[self._dataframe.index.size] = s
 
             # Save DataFrame to disk
-            self._dataframe.to_parquet(self._dataframe.paths.get_batch_path())
+
+            self._dataframe.to_hdf(self._dataframe.paths.get_batch_path(), key="batch", mode="a")
 
         return input_movie_paths, header_paths

--- a/serenity/improv_graph.yaml
+++ b/serenity/improv_graph.yaml
@@ -1,0 +1,13 @@
+actors:
+  ScanImageReceiver:
+    package: serenity.actors.datamanager
+    class: ScanImageReceiver
+    address: "tcp://0.0.0.0:9051"
+
+  MesmerizeWriter:
+    package: serenity.actors.datamanager
+    class: MesmerizeWriter
+
+connections:
+  ScanImageReceiver.q_out: [MesmerizeWriter.q_in]
+

--- a/serenity/io/__init__.py
+++ b/serenity/io/__init__.py
@@ -1,2 +1,3 @@
 from ._metadata import AcquisitionMetadata
 from ._frame import TwoPhotonFrame
+from ._server import SerenityServer

--- a/serenity/io/_frame.py
+++ b/serenity/io/_frame.py
@@ -177,7 +177,7 @@ class TwoPhotonFrame:
 
         return b
 
-    def append_header_file(self, path: Path | str):
+    def append_header_file(self, path: Path | str, channel: int):
         """
         Append header information from this frame to the header file at the given path
         """
@@ -186,7 +186,7 @@ class TwoPhotonFrame:
             raise FileExistsError(f"header does not exist at given location: {path}")
 
         with h5py.File(path, "r+") as f:
-            if not f.attrs["uid"] == str(self.acq_meta.uid):
+            if not f.attrs["uuid"] == str(self.acq_meta.uuids[channel]):
                 raise ValueError(
                     "acquisition uid of the given header file does not "
                     "match the acquisition uid of the current frame"

--- a/serenity/io/_frame.py
+++ b/serenity/io/_frame.py
@@ -194,7 +194,7 @@ class TwoPhotonFrame:
             for header_element in self.acq_meta.header_elements:
                 val = getattr(self, header_element.name)
                 # since it will be an array of size 1
-                f[header_element.name][self.index] = val.item()
+                f[header_element.name][self.index - 1] = val.item()
 
     def __eq__(self, other):
         """

--- a/serenity/io/_frame.py
+++ b/serenity/io/_frame.py
@@ -71,7 +71,7 @@ class TwoPhotonFrame:
         if from_matlab:
             # since matlab adds 60 bits of something as a header to each header element
             # only the last 4 bytes are our actual header element value
-            start_byte += 15 * 4
+            start_byte += 60
 
         for element in acq_meta.header_elements:
             # parse the header for this element
@@ -83,7 +83,11 @@ class TwoPhotonFrame:
             )
 
             # jump to next header element
-            start_byte = start_byte + element.nbytes
+            start_byte += element.nbytes
+
+            # add the 60 bits for matlab weirdness
+            if from_matlab:
+                start_byte += 60
 
         # parse channels
         if not from_matlab:

--- a/serenity/io/_metadata.py
+++ b/serenity/io/_metadata.py
@@ -1,4 +1,4 @@
-from uuid import UUID
+from uuid import UUID, uuid4
 from dataclasses import dataclass, asdict
 import json
 from pathlib import Path
@@ -49,7 +49,7 @@ class AcquisitionMetadata:
     database: str
         name of mongodb or "batch path" that this acquisition belongs to
 
-    uid: UUID
+    uuid: UUID
         identifier for this acquisition session, must be generated in ScanImageReceiver
 
     animal_id: str
@@ -72,7 +72,7 @@ class AcquisitionMetadata:
         descriptions of the elements that make up the header in each frame
     """
     database: str
-    uid: UUID
+    uuids: Tuple[UUID]
     animal_id: str
     channels: Tuple[Channel]
     framerate: float
@@ -99,15 +99,33 @@ class AcquisitionMetadata:
         return self.scanimage_meta["hStackManager"]["framesPerSlice"] + 100
 
     @classmethod
-    def from_json(cls, json_str: bytes, uid: UUID = None):
-        data = json.loads(json_str)
-        if uid is not None:
-            data["uid"] = uid
+    def from_jsons(cls, json_str: bytes, generate_uuid: bool = False):
+        """
+        Load from json formatted bytes
 
-        return cls.from_dict(data)
+        Parameters
+        ----------
+        json_str: bytes
+            jsone formatted bytes
+
+        generate_uuid: bool, default False
+            generate UUID, this is ONLY used when creating the
+            metadata for a new acquisition from scanimage
+
+        """
+        data = json.loads(json_str)
+
+        return cls.from_dict(data, generate_uuid=generate_uuid)
 
     @classmethod
-    def from_dict(cls, data: dict):
+    def from_json(cls, path: Path | str):
+        """load from json file on disk"""
+        d = json.load(open(path, "r"))
+
+        return cls.from_dict(d)
+
+    @classmethod
+    def from_dict(cls, data: dict, generate_uuid: bool = False):
         _channels = data.pop("channels")
 
         channels = list()
@@ -115,6 +133,26 @@ class AcquisitionMetadata:
             ch["shape"] = tuple(ch["shape"])
             channel_instance = Channel(**ch)
             channels.append(channel_instance)
+
+        # sort them so they are in order in case they were sent out of order
+        # they need to be sorted so we can assume uuids[i] always corresponds to channels[i]
+        # likewise for frame data
+        channel_indices = [ch.index for ch in channels]
+        channels_sorted = list()
+
+        for i in range(len(channel_indices)):
+            # get the unsorted position of channel_i
+            unsorted_ix = channel_indices.index(i)
+            # append at sorted position i
+            channels_sorted.append(channels[unsorted_ix])
+
+        if generate_uuid:
+            # when receiving brand new acq metadata from scanimage
+            uids = list()
+            for i in range(len(channels)):
+                uid = str(uuid4())
+                uids.append(uid)
+            data["uuids"] = tuple(uids)
 
         if "header_elements" in data.keys():
             _header_elements = data.pop("header_elements")
@@ -125,9 +163,9 @@ class AcquisitionMetadata:
                 )
             data["header_elements"] = tuple(header_elements)
 
-        return cls(channels=tuple(channels), **data)
+        return cls(channels=tuple(channels_sorted), **data)
 
-    def create_header_file(self, path: Path | str):
+    def create_header_file(self, path: Path | str, channel: int):
         """
         Create header file at given path, used to store frame headers for every frame
         """
@@ -139,19 +177,17 @@ class AcquisitionMetadata:
 
         with h5py.File(path, "w") as f:
             # store uid
-            f.attrs["uid"] = str(self.uid)
+            f.attrs["uuid"] = str(self.uuids[channel])
 
             # create dataset for each header element which will be stored as 1D array
             for header_element in self.header_elements:
                 f.create_dataset(header_element.name, shape=(n_frames,), dtype=header_element.dtype)
-
 
     def to_dict(self) -> dict:
         return asdict(self)
 
     def to_json(self) -> str:
         d = self.to_dict()
-        d["uid"] = str(d["uid"])
 
         return json.dumps(d)
 

--- a/serenity/io/_metadata.py
+++ b/serenity/io/_metadata.py
@@ -94,6 +94,10 @@ class AcquisitionMetadata:
     def nbytes_header(self) -> int:
         return sum(e.nbytes for e in self.header_elements)
 
+    def get_batch_item_path(self, channel_index: int) -> Path:
+        """path to the batch item dir that corresponds to the given channel data"""
+        return Path(self.database).parent.joinpath(self.uuids[channel_index])
+
     @property
     def n_frames(self) -> int:
         """number of frames set for this acquisition + 100"""

--- a/serenity/io/_metadata.py
+++ b/serenity/io/_metadata.py
@@ -77,6 +77,7 @@ class AcquisitionMetadata:
     channels: Tuple[Channel]
     framerate: float
     date: str
+    sub_session: int
     scanimage_meta: dict = None
     comments: str = None
 

--- a/serenity/io/_metadata.py
+++ b/serenity/io/_metadata.py
@@ -109,6 +109,15 @@ class AcquisitionMetadata:
             channel_instance = Channel(**ch)
             channels.append(channel_instance)
 
+        if "header_elements" in data.keys():
+            _header_elements = data.pop("header_elements")
+            header_elements: List[HeaderElement] = list()
+            for he in _header_elements:
+                header_elements.append(
+                    HeaderElement(**he)
+                )
+            data["header_elements"] = tuple(header_elements)
+
         return cls(channels=tuple(channels), **data)
 
     def to_dict(self) -> dict:
@@ -119,3 +128,7 @@ class AcquisitionMetadata:
         d["uid"] = str(d["uid"])
 
         return json.dumps(d)
+
+    def to_disk(self, path):
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f)

--- a/serenity/io/_server.py
+++ b/serenity/io/_server.py
@@ -4,7 +4,7 @@ from time import time, sleep
 
 import numpy as np
 import zmq
-from IPython.display import display, clear_output
+from IPython.display import clear_output
 
 
 class SerenityServer:

--- a/serenity/io/_server.py
+++ b/serenity/io/_server.py
@@ -123,7 +123,7 @@ class SerenityServer:
 
     def end_acq(self):
         # tell improv to end acq
-        self.socket.send(b"end-acquisition")
+        self.socket.send(b"end-acq")
 
         send_time = time()
         print("waiting for improv to acknowledge end of acquisition")
@@ -136,11 +136,8 @@ class SerenityServer:
                     self.socket_matlab.send_string(msg)
                     raise TimeoutError(msg)
                 sleep(1)
-                break
             else:
                 print(str(msg))
-                # reply to matlab acq ended
-                self.socket_matlab.send_string("serenity server and improv ended acquisition")
                 break
 
     def send_loop(self):
@@ -181,7 +178,7 @@ class SerenityServer:
                 # reply not yet received
                 except zmq.Again:
                     # if we've waited longer than 20ms for a reply, send again
-                    if now - send_time > 0.03:
+                    if now - send_time > 0.05:
                         self.current_failed_attempt += 1
                         break
                 # reply received, increment to next frame

--- a/serenity/io/scanimage_sender.py
+++ b/serenity/io/scanimage_sender.py
@@ -181,7 +181,7 @@ class SerenityServer:
                 # reply not yet received
                 except zmq.Again:
                     # if we've waited longer than 20ms for a reply, send again
-                    if now - send_time > 0.02:
+                    if now - send_time > 0.03:
                         self.current_failed_attempt += 1
                         break
                 # reply received, increment to next frame

--- a/serenity/io/scanimage_sender.py
+++ b/serenity/io/scanimage_sender.py
@@ -66,7 +66,7 @@ class ScanImageSender:
             try:
                 reply = self.socket.recv(zmq.NOBLOCK)
             except zmq.Again:
-                await asyncio.sleep(0.01)
+                pass
             else:
                 index = int(reply.decode())
                 self.remove_frame_from_buffer(index)
@@ -79,6 +79,7 @@ class ScanImageSender:
                 self.indices_received.append(index)
             finally:
                 self._check_for_missing_indices()
+                await asyncio.sleep(0.01)
 
     def _check_for_missing_indices(self):
         finished = sorted(self.indices_received)

--- a/serenity/io/scanimage_sender.py
+++ b/serenity/io/scanimage_sender.py
@@ -64,6 +64,8 @@ class ScanImageSender:
     async def reply_loop(self):
         while True:
             try:
+                # TODO: look into socket.poll()
+                # TODO: https://stackoverflow.com/questions/21089269/receive-all-available-messages-from-a-zeromq-pyzmq-socket 
                 reply = self.socket.recv(zmq.NOBLOCK)
             except zmq.Again:
                 pass

--- a/serenity/io/scanimage_sender.py
+++ b/serenity/io/scanimage_sender.py
@@ -96,7 +96,7 @@ class SerenityServer:
 
                 sleep(0.5)
             else:
-                self.socket_matlab.send(uid_reply)
+                self.socket_matlab.send_string(uid_reply)
                 break
 
         # start frame sending loop

--- a/serenity/io/scanimage_sender.py
+++ b/serenity/io/scanimage_sender.py
@@ -86,7 +86,7 @@ class SerenityServer:
             now = time()
             try:
                 # uuid from improv for this acquisition
-                uid_reply = str(self.socket.recv(zmq.NOBLOCK))
+                uid_reply = self.socket.recv_string(zmq.NOBLOCK, encoding="utf-8")
             except zmq.Again:
                 if now - t > 5:
                     msg = "Failed to receive reply for acquisition metadata, try `start_acq()` again."

--- a/serenity/io/scanimage_sender.py
+++ b/serenity/io/scanimage_sender.py
@@ -1,7 +1,6 @@
 from typing import *
-import asyncio
 from pathlib import Path
-from time import time
+from time import time, sleep
 
 import zmq
 
@@ -20,101 +19,55 @@ class ScanImageSender:
         # frames that have been sent
         self.indices_sent: List[int] = list()
 
-        # {frame_ix: time}, frames which have been sent but not received
-        self.indices_waiting: Dict[int, float] = dict()
-
-        # frames which have been sent but lost
-        self.missing_queue = list()
-
         self.current_index_read = 1
+        self.current_failed_attempt: int = 0
 
-        self.reply_task = asyncio.create_task(self.reply_loop())
-        self.send_task = asyncio.create_task(self.send_loop())
-
-    async def send_loop(self):
+    def send_loop(self):
         while True:
-            ix = self.current_index_read
+            data = self._read_frame_buffer(self.current_index_read)
 
-            self._send_frame(ix)
-            self.indices_sent.append(ix)
-            self.indices_waiting[ix] = time()
-            self.current_index_read += 1
+            # if frame buffer not yet ready for this index
+            if data is None:
+                # sleep for 5ms and go back to the top of the loop
+                sleep(0.005)
+                continue
 
-            # empty the missing queue
-            for mix in self.missing_queue:
-                self._send_frame(mix)
-                # reset the time
-                self.indices_waiting[mix] = time()
+            self.socket.send(data)
 
-            # clear the missing queue, we assume that it is more likely to be received than lost
-            # so if the frame is still missing after another send attempt we wait for it to be
-            # re-added to the `missing_queue`
-            self.missing_queue.clear()
+            send_time = time()
 
-            await asyncio.sleep(0.01)
+            while True:
+                now = time()
+                try:
+                    reply = self.socket.recv(zmq.NOBLOCK)
+                    print(reply)
+                # reply not yet received
+                except zmq.Again:
+                    # if we've waited longer than 10ms for a reply, send again
+                    if now - send_time > 0.01:
+                        self.current_failed_attempt += 1
+                        break
+                # reply received, increment to next frame
+                else:
+                    # send next frame
+                    self.current_index_read += 1
+                    self.current_failed_attempt = 0
 
-    def _send_frame(self, index: int):
-        data = self._read_frame_buffer(index)
+    def _get_frame_buffer_path(self, index: int):
+        return self.buffer_path.joinpath(f"{index}.bin")
 
-        if data is None:
-            return
-
-        self.socket.send(data)
-
-    async def reply_loop(self):
-        while True:
-            try:
-                # TODO: look into socket.poll()
-                # TODO: https://stackoverflow.com/questions/21089269/receive-all-available-messages-from-a-zeromq-pyzmq-socket 
-                reply = self.socket.recv(zmq.NOBLOCK)
-            except zmq.Again:
-                pass
-            else:
-                index = int(reply.decode())
-                self.remove_frame_from_buffer(index)
-
-                # remove from missing queue
-                # TODO: probably better to clear the missing queue from send_loop() and not here, but test it
-                # if index in self.missing_queue:
-                #     self.missing_queue.remove(index)
-
-                self.indices_received.append(index)
-            finally:
-                self._check_for_missing_indices()
-                await asyncio.sleep(0.01)
-
-    def _check_for_missing_indices(self):
-        finished = sorted(self.indices_received)
-
-        # make sure finished is consecutive integers
-        for i in range(len(self.indices_received) - 1):
-            diff = finished[i] - finished[i + 1]
-
-            # if non-consecutive, add all in-between indices to the missing queue
-            if diff > 1:
-                for j in range(i, i + diff):
-                    # add to missing queue
-                    self.missing_queue.append(j)
-
-        # check for any frames that haven't been received for a long time
-        now = time()
-        for ix in self.indices_waiting.keys():
-            delta = now - self.indices_waiting[ix]
-
-            # frames that were sent > 1 second ago but still not confirmed as received
-            if delta > 1:
-                self.missing_queue.append(ix)
-
-    def remove_frame_from_buffer(self, index: int):
-        self.indices_waiting.pop(index)
+    def _remove_from_from_buffer(self, index):
+        frame_buffer_path = self._get_frame_buffer_path(index)
+        frame_buffer_path.unlink()
 
     def _read_frame_buffer(self, index: int):
+        frame_buffer_path = self._get_frame_buffer_path(index)
         try:
-            with open(self.buffer_path.joinpath(f"{index}.bin"), "rb") as f:
+            with open(frame_buffer_path, "rb") as f:
                 data = f.read()
 
-        # if matlab is still writing the file
-        except PermissionError:
+        # if matlab is still writing the file or not yet written
+        except (PermissionError, FileNotFoundError):
             return None
         else:
             return data

--- a/serenity/io/scanimage_sender.py
+++ b/serenity/io/scanimage_sender.py
@@ -4,6 +4,7 @@ from time import time, sleep
 
 import numpy as np
 import zmq
+from IPython.display import display, clear_output
 
 
 class SerenityServer:
@@ -16,6 +17,7 @@ class SerenityServer:
         # for sending data to improv actor
         self.context = zmq.Context()
         self.socket = self.context.socket(zmq.REQ)
+        self.socket.setsockopt(zmq.REQ_RELAXED, 1)
         self.socket.connect(address_improv_server)
 
         # for receiving acq metadata from matlab
@@ -141,6 +143,13 @@ class SerenityServer:
 
     def send_loop(self):
         while True:
+            clear_output(wait=True)
+            print(
+                f"frame sent: {self.current_index_read}\n"
+                f"failures: {self.current_failed_attempt}\n"
+                f"frame received: {self.current_index_read - 1}"
+            )
+            
             # check if scanimage acq has ended
             self._check_end_acq()
 
@@ -153,12 +162,11 @@ class SerenityServer:
 
             # if frame buffer not yet ready for this index
             if data is None:
-                # sleep for 5ms and go back to the top of the loop
-                sleep(0.005)
+                # sleep for 2ms and go back to the top of the loop
+                sleep(0.002)
                 continue
                 
             self.socket.send(data)
-            print(f"sent frame: {self.current_index_read}")
 
             send_time = time()
             
@@ -167,15 +175,18 @@ class SerenityServer:
                 now = time()
                 try:
                     reply = self.socket.recv(zmq.NOBLOCK)
-                    print(f"received reply for: {np.frombuffer(reply, dtype=np.uint32)}")
                 # reply not yet received
                 except zmq.Again:
-                    # if we've waited longer than 100ms for a reply, send again
-                    if now - send_time > 1:
+                    # if we've waited longer than 20ms for a reply, send again
+                    if now - send_time > 0.02:
                         self.current_failed_attempt += 1
                         break
                 # reply received, increment to next frame
                 else:
+                    # bad frame
+                    if reply.decode("utf-8") == "bad frame":
+                        self.current_failed_attempt +=1
+                        break
                     # remove the replied frame from buffer
                     self._remove_from_from_buffer(self.current_index_read)
                     # increment to next frame

--- a/serenity/io/scanimage_sender.py
+++ b/serenity/io/scanimage_sender.py
@@ -1,6 +1,7 @@
 from typing import *
 import asyncio
 from pathlib import Path
+from time import time
 
 import zmq
 
@@ -13,24 +14,104 @@ class ScanImageSender:
 
         self.buffer_path = Path(buffer_path)
 
-        self.indices_finished: List[int] = list()
+        # frames that have been successfully received
+        self.indices_received: List[int] = list()
+
+        # frames that have been sent
+        self.indices_sent: List[int] = list()
+
+        # {frame_ix: time}, frames which have been sent but not received
+        self.indices_waiting: Dict[int, float] = dict()
+
+        # frames which have been sent but lost
+        self.missing_queue = list()
+
         self.current_index_read = 1
 
-    async def send_frame(self, index):
-        data = self.read_si_binary(index)
+        self.reply_task = asyncio.create_task(self.reply_loop())
+        self.send_task = asyncio.create_task(self.send_loop())
+
+    async def send_loop(self):
+        while True:
+            ix = self.current_index_read
+
+            self._send_frame(ix)
+            self.indices_sent.append(ix)
+            self.indices_waiting[ix] = time()
+            self.current_index_read += 1
+
+            # empty the missing queue
+            for mix in self.missing_queue:
+                self._send_frame(mix)
+                # reset the time
+                self.indices_waiting[mix] = time()
+
+            # clear the missing queue, we assume that it is more likely to be received than lost
+            # so if the frame is still missing after another send attempt we wait for it to be
+            # re-added to the `missing_queue`
+            self.missing_queue.clear()
+
+            await asyncio.sleep(0.01)
+
+    def _send_frame(self, index: int):
+        data = self._read_frame_buffer(index)
+
+        if data is None:
+            return
 
         self.socket.send(data)
-        # wait for reply
-        # self.socket.recv()
 
-    async def receive_reply(self):
-        pass
+    async def reply_loop(self):
+        while True:
+            try:
+                reply = self.socket.recv(zmq.NOBLOCK)
+            except zmq.Again:
+                await asyncio.sleep(0.01)
+            else:
+                index = int(reply.decode())
+                self.remove_frame_from_buffer(index)
+
+                # remove from missing queue
+                # TODO: probably better to clear the missing queue from send_loop() and not here, but test it
+                # if index in self.missing_queue:
+                #     self.missing_queue.remove(index)
+
+                self.indices_received.append(index)
+            finally:
+                self._check_for_missing_indices()
+
+    def _check_for_missing_indices(self):
+        finished = sorted(self.indices_received)
+
+        # make sure finished is consecutive integers
+        for i in range(len(self.indices_received) - 1):
+            diff = finished[i] - finished[i + 1]
+
+            # if non-consecutive, add all in-between indices to the missing queue
+            if diff > 1:
+                for j in range(i, i + diff):
+                    # add to missing queue
+                    self.missing_queue.append(j)
+
+        # check for any frames that haven't been received for a long time
+        now = time()
+        for ix in self.indices_waiting.keys():
+            delta = now - self.indices_waiting[ix]
+
+            # frames that were sent > 1 second ago but still not confirmed as received
+            if delta > 1:
+                self.missing_queue.append(ix)
 
     def remove_frame_from_buffer(self, index: int):
-        pass
+        self.indices_waiting.pop(index)
 
-    def read_si_binary(self, index: int):
-        with open(self.buffer_path.joinpath(f"{index}.bin"), "rb") as f:
-            data = f.read()
+    def _read_frame_buffer(self, index: int):
+        try:
+            with open(self.buffer_path.joinpath(f"{index}.bin"), "rb") as f:
+                data = f.read()
 
-        return data
+        # if matlab is still writing the file
+        except PermissionError:
+            return None
+        else:
+            return data

--- a/serenity/io/scanimage_sender.py
+++ b/serenity/io/scanimage_sender.py
@@ -25,11 +25,14 @@ class SerenityServer:
 
         # frame buffer on SSD
         self.buffer_path = Path(buffer_path)
+        self.current_buffer_path: Path = None
 
         self.indices_received = None
         self.indices_sent = None
         self.current_index_read = None
         self.current_failed_attempt = None
+
+        self.current_uid = None
 
         self.acq_ended = None
         self.last_frame_ix = None
@@ -83,7 +86,7 @@ class SerenityServer:
             now = time()
             try:
                 # uuid from improv for this acquisition
-                uid_reply = self.socket.recv(zmq.NOBLOCK)
+                uid_reply = str(self.socket.recv(zmq.NOBLOCK))
             except zmq.Again:
                 if now - t > 5:
                     msg = "Failed to receive reply for acquisition metadata, try `start_acq()` again."
@@ -97,6 +100,9 @@ class SerenityServer:
                 break
 
         # start frame sending loop
+        self.current_uid = uid_reply
+        self.current_buffer_path = self.buffer_path.joinpath(self.current_uid)
+
         self.acq_ended = False
         self.last_frame_ix = None
         self.send_loop()

--- a/serenity/io/scanimage_sender.py
+++ b/serenity/io/scanimage_sender.py
@@ -1,0 +1,36 @@
+from typing import *
+import asyncio
+from pathlib import Path
+
+import zmq
+
+
+class ScanImageSender:
+    def __init__(self, address: str, buffer_path: Path | str):
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.REQ)
+        self.socket.connect(address)
+
+        self.buffer_path = Path(buffer_path)
+
+        self.indices_finished: List[int] = list()
+        self.current_index_read = 1
+
+    async def send_frame(self, index):
+        data = self.read_si_binary(index)
+
+        self.socket.send(data)
+        # wait for reply
+        # self.socket.recv()
+
+    async def receive_reply(self):
+        pass
+
+    def remove_frame_from_buffer(self, index: int):
+        pass
+
+    def read_si_binary(self, index: int):
+        with open(self.buffer_path.joinpath(f"{index}.bin"), "rb") as f:
+            data = f.read()
+
+        return data

--- a/serenity/mesmerize_utils.py
+++ b/serenity/mesmerize_utils.py
@@ -1,0 +1,23 @@
+import mesmerize_core
+
+
+# additional columns that we use
+ADD_COLUMNS = [
+    "animal_id",
+    "framerate",
+    "date",
+    "channel_index",
+    "channel_name",
+    "channel_colors",
+    "channel_genotype",
+    "channel_indicator"
+]
+
+
+def load_batch(path, file_format="parquet"):
+    """thin wrapper around mesmerize_core.load_batch"""
+    return mesmerize_core.load_batch(path, file_format=file_format)
+
+
+def create_batch(path, file_format="parquet"):
+    return mesmerize_core.create_batch(path, file_format=file_format, add_columns=ADD_COLUMNS)

--- a/serenity/mesmerize_utils.py
+++ b/serenity/mesmerize_utils.py
@@ -8,16 +8,16 @@ ADD_COLUMNS = [
     "date",
     "channel_index",
     "channel_name",
-    "channel_colors",
+    "channel_color",
     "channel_genotype",
     "channel_indicator"
 ]
 
 
-def load_batch(path, file_format="parquet"):
+def load_batch(path, file_format="hdf"):
     """thin wrapper around mesmerize_core.load_batch"""
     return mesmerize_core.load_batch(path, file_format=file_format)
 
 
-def create_batch(path, file_format="parquet"):
+def create_batch(path, file_format="hdf"):
     return mesmerize_core.create_batch(path, file_format=file_format, add_columns=ADD_COLUMNS)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    name='serenity',
+    version='0.1.0a1',
+    packages=['serenity', 'serenity.io', 'serenity.actors'],
+    url='https://github.com/kushalkolar/serenity',
+    license='GPLv3',
+    author='Kushal Kolar',
+    author_email='',
+    description='Realtime analysis and visualization of calcium imaging data  '
+)


### PR DESCRIPTION
This is working perfectly to send frames along with arduino relayed trigger. Timing are just as good as https://github.com/kushalkolar/serenity/pull/20#issuecomment-1524948270 .

No frames are ever duplicated, can check with `len({f for f in vid})` where vid is a `LazyTiff`.

histogram of `np.ptp(np.diff(timestamps))`
![download](https://user-images.githubusercontent.com/9403332/235349640-c6328501-2cc1-4124-9612-83e58e5c1e71.png)

Can also get trigger info
![download](https://user-images.githubusercontent.com/9403332/235349643-54892a2f-7df6-43a9-ae35-412b51ebb5bf.png)

and trial index for each frame based on the trigger
![download](https://user-images.githubusercontent.com/9403332/235349651-5a2183e9-3e8d-49b4-b6ec-c4eae5016459.png)

Used a stopwatch to measure that the timing are correct with scanimage frame indices shown on the GUI, it seems to be correct. However it seems like each 25s wavesurfer sweep is actually ~25.3 with a delay of ~0.3s between sweeps, need to verify this. Or the real framerate of scanimage isn't really 30.04 but slightly lower

Last thing to do is OnACID actor, thoughts here: https://github.com/kushalkolar/serenity/pull/20#issuecomment-1528750450